### PR TITLE
Validate --wip value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate clap;
 extern crate chrono;
 extern crate reqwest;
@@ -60,7 +61,7 @@ fn run(app: ArgMatches) {
     let today = Local::now().format("%Y-%m-%d");
     let created = today.to_string();
     let username = env!("ESA_NIPPOU_USERNAME").to_string();
-    let wip = FromStr::from_str(app.value_of("wip").unwrap()).unwrap();
+    let wip = value_t_or_exit!(app.value_of("wip"), bool);
     let query = build_query(created, username, wip);
 
     let posts_client = reqwest::Client::new();


### PR DESCRIPTION
- use `value_t_or_exit!`
  - https://docs.rs/clap/2.32.0/clap/macro.value_t_or_exit.html

example

```console
$ ./target/debug/esa-nippou --wip=falseeee
error: Invalid value: The argument 'falseeee' isn't a valid value
```