### PR TITLE
Add since/until date option

### DIFF
--- a/src/esa/query.rs
+++ b/src/esa/query.rs
@@ -25,10 +25,20 @@ impl Query {
         }
     }
 
-    pub fn updated(&self, updated: String) -> Query {
+    pub fn updated_gt(&self, updated: String) -> Query {
         Query {
             string: format!(
-                "{self} updated:{updated}",
+                "{self} updated:>{updated}",
+                self = &self.string,
+                updated = updated
+            ),
+        }
+    }
+
+    pub fn updated_lt(&self, updated: String) -> Query {
+        Query {
+            string: format!(
+                "{self} updated:<{updated}",
                 self = &self.string,
                 updated = updated
             ),
@@ -61,24 +71,37 @@ mod tests {
     }
 
     #[test]
-    fn build_query_updated() {
+    fn build_query_updated_gt() {
         let updated = "2018-08-26".to_string();
-        let subject = Query::new().updated(updated).to_string();
+        let subject = Query::new().updated_gt(updated).to_string();
 
-        assert_eq!(subject, " updated:2018-08-26");
+        assert_eq!(subject, " updated:>2018-08-26");
+    }
+
+    #[test]
+    fn build_query_updated_lt() {
+        let updated = "2018-08-26".to_string();
+        let subject = Query::new().updated_lt(updated).to_string();
+
+        assert_eq!(subject, " updated:<2018-08-26");
     }
 
     #[test]
     fn build_query_chain() {
         let wip = true;
         let screen_name = "mizukmb".to_string();
-        let updated = "2018-08-26".to_string();
+        let updated_gt = "2018-08-22".to_string();
+        let updated_lt = "2018-08-26".to_string();
         let subject = Query::new()
             .wip(wip)
             .user(screen_name)
-            .updated(updated)
+            .updated_gt(updated_gt)
+            .updated_lt(updated_lt)
             .to_string();
 
-        assert_eq!(subject, " wip:true user:mizukmb updated:2018-08-26");
+        assert_eq!(
+            subject,
+            " wip:true user:mizukmb updated:>2018-08-22 updated:<2018-08-26"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,6 @@ fn extract(value: esa::api::Posts) -> Vec<article::Article> {
     let mut articles: Vec<article::Article> = Vec::new();
 
     for i in value.posts {
-        // `XXX.as_str().unwrap().to_string()` convert from JSON to String without `""`
-        // see: https://github.com/serde-rs/json/issues/367
         articles.push(article::Article::new((
             i.full_name,
             i.url,


### PR DESCRIPTION
```diff
./target/debug/esa-nippou --help
esa-nippou 0.4.1
mizukmb <mizukmb6@gmail.com>
Print today's your esa.io articles

USAGE:
    esa-nippou [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
+    -s, --since-date <DATE>    Retrieves esa.io articles since the date
+    -u, --until-date <DATE>    Retrieves esa.io articles until the date
    -w, --wip <BOOL>           Print with WIP article only (true|false)

SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    init    Initialize configurations interactively
```