### PR TITLE
Add option not_in

### DIFF
--- a/src/esa/query.rs
+++ b/src/esa/query.rs
@@ -45,6 +45,12 @@ impl Query {
         }
     }
 
+    pub fn not_in(&self, keyword: String) -> Query {
+        Query{
+            string: format!("{self} -in:{keyword}", self=&self.string, keyword=keyword),
+        }
+    }
+
     pub fn to_string(self) -> String {
         self.string
     }
@@ -84,6 +90,14 @@ mod tests {
         let subject = Query::new().updated_lt(updated).to_string();
 
         assert_eq!(subject, " updated:<2018-08-26");
+    }
+
+    #[test]
+    fn build_query_not_in() {
+        let keyword = "category".to_string();
+        let subject = Query::new().not_in(keyword).to_string();
+
+        assert_eq!(subject, " -in:category");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,12 @@ fn run(app: ArgMatches) {
         query
     };
 
+    query = if app.is_present("not_in") {
+        query.not_in(app.value_of("not_in").unwrap().to_string())
+    } else {
+        query
+    };
+
     let updated_articles = post(&posts_url, &query.to_string(), &access_token);
 
     println!("### {team}.esa.io", team = team);
@@ -164,6 +170,13 @@ fn main() {
                 .long("until-date")
                 .value_name("DATE")
                 .help("Retrieves esa.io articles until the date")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("not_in")
+                .long("not-in")
+                .value_name("KEYWORD")
+                .help("Exclude to get not forward match keyword in category")
                 .takes_value(true),
         )
         .subcommand(SubCommand::with_name("init").about("Initialize configurations interactively"))


### PR DESCRIPTION
- Exclude to get not forward match keyword in category
- reference: https://docs.esa.io/posts/104

> in:keyword カテゴリ名がkeywordから始まるものを絞り込み(前方一致)


