### PR TITLE
Migrate Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "esa-nippou"
 version = "1.0.1"
 authors = ["mizukmb <mizukmb6@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 clap = "2.31.2"


### PR DESCRIPTION
ref: https://rust-lang-nursery.github.io/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html