### PR TITLE
Add option format

### DIFF
--- a/src/article.rs
+++ b/src/article.rs
@@ -63,4 +63,31 @@ impl Article {
 
         md
     }
+
+    pub fn to_scrapbox_link(&self) -> String {
+        let members_url = format!("https://{team}.esa.io/members", team = self.team);
+        let mut sb = format!(" [{title} {url}]", title = self.title, url = self.url);
+
+        if self.created_at == self.updated_at {
+            sb = format!(
+                "{sb} created by [{created_by} {members_url}/{created_by}]",
+                sb = &sb,
+                created_by = self.created_by,
+                members_url = members_url
+            );
+        } else {
+            sb = format!(
+                "{sb} updated by [{updated_by} {members_url}/{updated_by}]",
+                sb = &sb,
+                updated_by = self.updated_by,
+                members_url = members_url
+            );
+        }
+
+        if self.wip {
+            sb = format!("{sb} [* WIP]", sb = &sb);
+        }
+
+        sb
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,12 +115,29 @@ fn run(app: ArgMatches) {
 
     let updated_articles = post(&posts_url, &query.to_string(), &access_token, team.clone());
 
-    println!("### {team}.esa.io", team = team);
-    println!(""); // for new line
+    let format = match app.value_of("format") {
+        Some(v) => v,
+        None => "markdown",
+    };
 
-    for article in updated_articles {
-        println!("{}", article.to_markdown_link());
+    match format {
+        "scrapbox" => {
+            println!("[*** {team}.esa.io]", team = team);
+
+            for article in updated_articles {
+                println!("{}", article.to_scrapbox_link());
+            }
+        },
+        "markdown" | _ => {
+            println!("### {team}.esa.io", team = team);
+            println!(""); // for new line
+
+            for article in updated_articles {
+                println!("{}", article.to_markdown_link());
+            }
+        },
     }
+
 }
 
 fn main() {
@@ -132,6 +149,14 @@ fn main() {
         .version(version)
         .author(author)
         .about(about)
+        .arg(
+            Arg::with_name("format")
+                .short("f")
+                .long("format")
+                .value_name("FORMAT")
+                .help("Select format type: markdown (default), scrapbox")
+                .takes_value(true),
+        )
         .arg(
             Arg::with_name("wip")
                 .short("w")


### PR DESCRIPTION
Format Types

- scrapbox
- markdown

## example of scrapbox format

reference: https://scrapbox.io/help-jp/ブラケティング

```
[*** example.esa.io]
 [User/mizukmb/example https://example.esa.io/posts/12345] created by [mizukmb https://example.esa.io/members/mizukmb]
```